### PR TITLE
feat: move organism back to obs (#3)

### DIFF
--- a/hca_schema_validator/src/hca_schema_validator/__init__.py
+++ b/hca_schema_validator/src/hca_schema_validator/__init__.py
@@ -1,6 +1,11 @@
 """HCA Schema Validator - HCA-specific extensions for cellxgene schema validation."""
 
+# Define constants first (before importing validator to avoid circular import)
+__version__ = "0.1.0"
+__schema_version__ = "1.0.0"  # HCA schema version (independent from CELLxGENE)
+__schema_reference_url__ = "https://data.humancellatlas.org/metadata"  # Static URL, no version in path
+
+# Import after constants are defined
 from .validator import HCAValidator
 
-__version__ = "0.1.0"
 __all__ = ["HCAValidator"]

--- a/hca_schema_validator/src/hca_schema_validator/schema_definitions/hca_schema_definition.yaml
+++ b/hca_schema_validator/src/hca_schema_validator/schema_definitions/hca_schema_definition.yaml
@@ -1,0 +1,839 @@
+title: Corpora schema version 7.0.0
+type: anndata
+# If sparsity of any expression matrix is greater than this and not csr sparse matrix, then there will be warning.
+sparsity: 0.5
+# Perform the checks for "raw" requirements IF:
+raw:
+  obs:
+    assay_ontology_term_id:
+      descendants_of_all:
+        terms:
+          - EFO:0010891 # scATAC-seq
+          - EFO:0008913 # single-cell-RNA-sequencing
+      not_descendants_of:
+        EFO:
+          - EFO:0007045 # ATAC-seq
+          - EFO:0008804 # Methyl-seq
+          - EFO:0000751 # methylation profiling
+          - EFO:0008939 # snmC-seq
+components:
+  uns:
+    type: dict
+    required: True
+    reserved_columns:
+      - schema_version
+      - schema_reference
+      - citation
+    deprecated_columns:
+      - X_normalization
+      - default_field
+      - layer_descriptions
+      - tags
+      - version
+      - contributors
+      - preprint_doi
+      - project_description
+      - project_links
+      - project_name
+      - publication_doi
+    keys:
+      title:
+        type: string
+        required: True
+      batch_condition:
+        type: list
+        element_type: match_obs_columns
+      default_embedding:
+        type: match_obsm_keys
+      X_approximate_distribution:
+        type: string
+        enum:
+          - count
+          - normal
+  var:
+    type: dataframe
+    required: True
+    warn_if_less_than_rows: 20000
+    index:
+      unique: true
+      type: feature_id
+      add_labels:
+        - type: feature_id
+          to_column: feature_name
+        - type: feature_reference
+          to_column: feature_reference
+        - type: feature_biotype
+          to_column: feature_biotype
+        - type: feature_length
+          to_column: feature_length
+        - type: feature_type
+          to_column: feature_type
+    # All columns are required
+    columns:
+      feature_is_filtered:
+        type: feature_is_filtered
+  varm:
+    type: annotation_mapping
+  varp:
+    type: annotation_mapping
+  obsm:
+    type: annotation_mapping
+    required: True
+  obsp:
+    type: annotation_mapping
+  raw.var:
+    type: dataframe
+    forbidden_columns: # These columns must not be present in the dataframe
+      - feature_is_filtered
+    index:
+      unique: true
+      type: feature_id
+      add_labels:
+        - type: feature_id
+          to_column: feature_name
+        - type: feature_reference
+          to_column: feature_reference
+        - type: feature_biotype
+          to_column: feature_biotype
+        - type: feature_length
+          to_column: feature_length
+        - type: feature_type
+          to_column: feature_type
+  obs:
+    type: dataframe
+    required: True
+    index:
+      unique: true
+    deprecated_columns:
+      - ethnicity
+      - ethnicity_ontology_term_id
+    reserved_columns:
+      - observation_joinid
+    columns:
+      cell_type_ontology_term_id:
+        error_message_suffix: >-
+          cell_type_ontology_term_id must be a valid ontology term of CL or 'unknown'. WBbt, ZFA, and FBbt terms can be allowed depending on the organism. 'na' is allowed if tissue_type is 'cell line'.
+        type: curie
+        curie_constraints:
+          ontologies:
+            - CL
+            - ZFA
+            - FBbt
+            - WBbt
+          exceptions:
+            - unknown
+          allowed:
+            terms:
+              CL:
+                - CL:0000000
+            ancestors:
+              ZFA:
+                - ZFA:0009000
+              FBbt:
+                - FBbt:00007002
+              WBbt:
+                - WBbt:0004017
+              CL:
+                - CL:0000000
+          forbidden:
+            ancestors:
+              WBbt:
+                - WBbt:0006803
+            terms:
+              - CL:0000255
+              - CL:0000257
+              - CL:0000548
+              - WBbt:0006803
+        dependencies:
+          - rule:
+              column: tissue_type
+              match_exact:
+                terms:
+                  - cell line
+            type: curie
+            curie_constraints:
+              ontologies:
+                - CL
+                - ZFA
+                - FBbt
+                - WBbt
+              exceptions:
+                - unknown
+                - na
+              allowed:
+                terms:
+                  CL:
+                    - CL:0000000
+                ancestors:
+                  ZFA:
+                    - ZFA:0009000
+                  FBbt:
+                    - FBbt:00007002
+                  WBbt:
+                    - WBbt:0004017
+                  CL:
+                    - CL:0000000
+              forbidden:
+                ancestors:
+                  WBbt:
+                    - WBbt:0006803
+                terms:
+                  - CL:0000255
+                  - CL:0000257
+                  - CL:0000548
+                  - WBbt:0006803
+        add_labels:
+          - type: curie
+            to_column: cell_type
+      assay_ontology_term_id:
+        error_message_suffix: >-
+          Only descendant terms of either 'EFO:0002772' or 'EFO:0010183' are allowed for assay_ontology_term_id
+        type: curie
+        curie_constraints:
+          ontologies:
+            - EFO
+          allowed:
+            ancestors:
+              EFO:
+                - EFO:0002772
+                - EFO:0010183
+        add_labels:
+          - type: curie
+            to_column: assay
+      disease_ontology_term_id:
+        error_message_suffix: "Individual terms 'PATO:0000461' (normal), 'MONDO:0021178' (injury) or descendant terms thereof, or descendant terms of 'MONDO:0000001' (disease) are allowed. Multiple terms are supported if in ascending lexical order with the delimiter ` || ` if all terms are valid MONDO terms."
+        type: curie
+        curie_constraints:
+          ontologies:
+            - MONDO
+            - PATO
+          allowed:
+            terms:
+              PATO:
+                - PATO:0000461
+              MONDO:
+                - MONDO:0021178
+            ancestors:
+              MONDO:
+                - MONDO:0000001
+                - MONDO:0021178
+          multi_term:
+            delimiter: " || "
+            sorted: True
+            # Multiple terms only allowed for MONDO
+            multi_term_constraints:
+              ontologies:
+                - MONDO
+        add_labels:
+          - type: curie
+            to_column: disease
+      sex_ontology_term_id:
+        type: curie
+        dependencies:
+          - # If organism is c. elegans
+            rule:
+                column: organism_ontology_term_id
+                match_exact:
+                  terms:
+                    - NCBITaxon:6239
+            error_message_suffix: >-
+              When 'organism_ontology_term_id' is 'NCBITaxon:6239' (Caenorhabditis elegans), 'sex_ontology_term_id' MUST be 'PATO:0000384' for male, 'PATO:0001340' for hermaphrodite, 'na' or 'unknown'.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - PATO
+              allowed:
+                terms:
+                  PATO:
+                    - PATO:0000384
+                    - PATO:0001340
+              exceptions:
+                - unknown
+                - na
+          - # If organism is not c. elegans
+            rule:
+                column: organism_ontology_term_id
+                exclude_exact:
+                  terms:
+                    - NCBITaxon:6239
+            error_message_suffix: >-
+              Only 'PATO:0000383', 'PATO:0000384', 'PATO:0001340', 'na' or 'unknown' are allowed.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - PATO
+              exceptions:
+                - unknown
+                - na
+              allowed:
+                terms:
+                  PATO:
+                    - PATO:0000383
+                    - PATO:0000384
+                    - PATO:0001340
+          - # If tissue_type is "cell line", sex_ontology_term_id must be "na"
+            rule:
+              column: tissue_type
+              match_exact:
+                terms:
+                  - cell line
+            error_message_suffix: >-
+              When 'tissue_type' is 'cell line', 'sex_ontology_term_id' MUST be 'na'.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - NA
+              exceptions:
+                - na
+          - # If tissue_type is not "cell line", sex_ontology_term_id cannot be "na"
+            rule:
+              column: tissue_type
+              exclude_exact:
+                terms:
+                  - cell line
+            error_message_suffix: >-
+              When 'tissue_type' is not 'cell line', 'sex_ontology_term_id' cannot be 'na'.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - PATO
+              allowed:
+                terms:
+                  PATO:
+                    - PATO:0000383
+                    - PATO:0000384
+                    - PATO:0001340
+              exceptions:
+                - unknown
+        add_labels:
+          - type: curie
+            to_column: sex
+      tissue_ontology_term_id:
+        type: curie
+        dependencies:
+          - # If tissue_type is tissue
+            rule:
+              column: tissue_type
+              match_exact:
+                terms:
+                  - tissue
+            error_message_suffix: >-
+              When 'tissue_type' is 'tissue', 'tissue_ontology_term_id' must be a valid UBERON, ZFA, FBbt, or WBbt term.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - UBERON
+                - ZFA
+                - FBbt
+                - WBbt
+              allowed:
+                ancestors:
+                  ZFA:
+                    - ZFA:0100000
+                  FBbt:
+                    - FBbt:10000000
+                  WBbt:
+                    - WBbt:0005766
+                  UBERON:
+                    - UBERON:0001062
+              forbidden:
+                terms:
+                  - ZFA:0009000
+                  - ZFA:0001093
+                  - FBbt:00007002
+                  - WBbt:0007849
+                  - WBbt:0007850
+                  - WBbt:0008595
+                  - WBbt:0004017
+                  - WBbt:0006803
+                ancestors:
+                  ZFA:
+                    - ZFA:0009000
+                  WBbt:
+                    - WBbt:0004017
+                    - WBbt:0006803
+                  FBbt:
+                    - FBbt:00007002
+          - # If tissue_type is organoid
+            rule:
+              column: tissue_type
+              match_exact:
+                terms:
+                  - organoid
+            error_message_suffix: >-
+              When 'tissue_type' is 'organoid', 'tissue_ontology_term_id' must be a valid UBERON, ZFA, FBbt, or WBbt term.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - UBERON
+                - ZFA
+                - FBbt
+                - WBbt
+              allowed:
+                ancestors:
+                  ZFA:
+                    - ZFA:0100000
+                  FBbt:
+                    - FBbt:10000000
+                  WBbt:
+                    - WBbt:0005766
+                  UBERON:
+                    - UBERON:0001062
+              forbidden:
+                terms:
+                  - ZFA:0009000
+                  - ZFA:0001093
+                  - FBbt:00007002
+                  - WBbt:0007849
+                  - WBbt:0007850
+                  - WBbt:0008595
+                  - WBbt:0004017
+                  - WBbt:0006803
+                  - UBERON:0000922
+                ancestors:
+                  ZFA:
+                    - ZFA:0009000
+                  WBbt:
+                    - WBbt:0004017
+                    - WBbt:0006803
+                  FBbt:
+                    - FBbt:00007002
+          - # If tissue_type is primary cell culture
+            rule:
+              column: tissue_type
+              match_exact:
+                terms:
+                  - primary cell culture
+            error_message_suffix: >-
+              When 'tissue_type' is 'primary cell culture', 'tissue_ontology_term_id' MUST follow the validation rules for cell_type_ontology_term_id.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - CL
+                - ZFA
+                - FBbt
+                - WBbt
+              exceptions:
+                - unknown
+              allowed:
+                ancestors:
+                  ZFA:
+                  - ZFA:0009000
+                  FBbt:
+                  - FBbt:00007002
+                  WBbt:
+                  - WBbt:0004017
+                  CL:
+                  - CL:0000000
+              forbidden:
+                ancestors:
+                  WBbt:
+                  - WBbt:0006803
+                terms:
+                  - CL:0000255
+                  - CL:0000257
+                  - CL:0000548
+                  - WBbt:0006803
+          - # If tissue_type is cell line
+            rule:
+              column: tissue_type
+              match_exact:
+                terms:
+                  - cell line
+            error_message_suffix: >-
+              When 'tissue_type' is 'cell line', 'tissue_ontology_term_id' must be a valid CVCL term.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - CVCL
+        add_labels:
+          - type: curie
+            to_column: tissue
+      self_reported_ethnicity_ontology_term_id:
+        type: curie
+        dependencies:
+          - # If organism is Human and tissue_type is not "cell line"
+            rule:
+              - column: organism_ontology_term_id
+                match_exact:
+                  terms:
+                    - NCBITaxon:9606
+              - column: tissue_type
+                exclude_exact:
+                  terms:
+                    - cell line
+            error_message_suffix: >-
+              When 'organism_ontology_term_id' is 'NCBITaxon:9606' (Homo sapiens) and 'tissue_type' is not 'cell line', self_reported_ethnicity_ontology_term_id MUST be formatted as one or more AfPO or HANCESTRO terms that are descendants of 'HANCESTRO:0601' for ethnicity category or 'HANCESTRO:0602' for geography-based population category, in ascending lexical order with the delimiter ` || `, or 'unknown' if unavailable.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - HANCESTRO
+                - AFPO
+              exceptions:
+                - unknown
+              allowed:
+                ancestors:
+                  HANCESTRO:
+                    - HANCESTRO:0601
+                    - HANCESTRO:0602
+                  AFPO:
+                    - HANCESTRO:0601
+                    - HANCESTRO:0602
+              multi_term:
+                delimiter: " || "
+                sorted: True
+          - # If organism is not Human, self_reported_ethnicity_ontology_term_id must be "na"
+            rule:
+              column: organism_ontology_term_id
+              exclude_exact:
+                terms:
+                  - NCBITaxon:9606
+            error_message_suffix: >-
+              When 'organism_ontology_term_id' is NOT 'NCBITaxon:9606' (Homo sapiens), self_reported_ethnicity_ontology_term_id MUST be 'na'.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - NA
+              exceptions:
+                - na
+          - # If tissue_type is "cell line", self_reported_ethnicity_ontology_term_id must be "na"
+            rule:
+              column: tissue_type
+              match_exact:
+                terms:
+                  - cell line
+            error_message_suffix: >-
+              When 'tissue_type' is 'cell line', 'self_reported_ethnicity_ontology_term_id' MUST be 'na'.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - NA
+              exceptions:
+                - na
+        add_labels:
+          - type: curie
+            to_column: self_reported_ethnicity
+      development_stage_ontology_term_id:
+        type: curie
+        dependencies:
+          - # If organism is Human
+            rule:
+              column: organism_ontology_term_id
+              match_exact:
+                terms:
+                  - NCBITaxon:9606
+            error_message_suffix: >-
+              When 'organism_ontology_term_id' is 'NCBITaxon:9606' (Homo sapiens), 'development_stage_ontology_term_id' MUST be the most accurate descendant of 'HsapDv:0000001', 'na', or unknown.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - HsapDv
+              allowed:
+                ancestors:
+                  HsapDv:
+                    - HsapDv:0000001
+              exceptions:
+                - unknown
+                - na
+          - # If organism is Mouse
+            rule:
+              column: organism_ontology_term_id
+              match_ancestors_inclusive:
+                ancestors:
+                  - NCBITaxon:10090
+            error_message_suffix: >-
+              When 'organism_ontology_term_id' is 'NCBITaxon:10090' (Mus musculus) or one of its descendants, 'development_stage_ontology_term_id' MUST be the most accurate descendant of 'MmusDv:0000001', 'na', or unknown.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - MmusDv
+              allowed:
+                ancestors:
+                  MmusDv:
+                    - MmusDv:0000001
+              exceptions:
+                - unknown
+                - na
+          - # If organism is Zebrafish
+            rule:
+              column: organism_ontology_term_id
+              match_exact:
+                terms:
+                  - NCBITaxon:7955
+            error_message_suffix: >-
+             When 'organism_ontology_term_id' is 'NCBITaxon:7955' (Danio rerio), 'development_stage_ontology_term_id' MUST be the most accurate descendant of 'ZFS:0100000' and it MUST NOT be 'ZFS:0000000' for Unknown. The str 'unknown' or 'na' is acceptable.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - ZFA
+              allowed:
+                ancestors:
+                  ZFA:
+                    - ZFS:0100000
+              forbidden:
+                terms:
+                  - ZFS:0000000
+              exceptions:
+                - unknown
+                - na
+          - # If organism is Fruit fly
+            rule:
+              column: organism_ontology_term_id
+              match_exact:
+                terms:
+                  - NCBITaxon:7227
+            error_message_suffix: >-
+             When 'organism_ontology_term_id' is 'NCBITaxon:7227' (Drosophila melanogaster), 'development_stage_ontology_term_id' MUST be either the most accurate descendant of FBdv:00007014 for adult age in days or the most accurate descendant of FBdv:00005259 for developmental stage excluding FBdv:00007012 for life stage. The str 'unknown' or 'na' is acceptable.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - FBdv
+              allowed:
+                ancestors:
+                  FBdv: 
+                    - FBdv:00007014
+                    - FBdv:00005259
+              forbidden:
+                terms:
+                  - FBdv:00007012
+              exceptions:
+                - unknown
+                - na
+          - # If organism is C. elegans
+            rule:
+                column: organism_ontology_term_id
+                match_exact:
+                  terms:
+                    - NCBITaxon:6239
+            error_message_suffix: >-
+             When 'organism_ontology_term_id' is 'NCBITaxon:6239' (Caenorhabditis elegans), 'development_stage_ontology_term_id' MUST be WBls:0000669 for unfertilized egg Ce, the most accurate descendant of WBls:0000803 for C. elegans life stage occurring during embryogenesis, or the most accurate descendant of WBls:0000804 for C. elegans life stage occurring post embryogenesis. The str 'unknown' or 'na' is acceptable.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - WBls
+              allowed:
+                ancestors:
+                  WBls:
+                    - WBls:0000803
+                    - WBls:0000804
+                terms:
+                  WBls:
+                    - WBls:0000669
+              exceptions:
+                - unknown
+                - na
+          - # If organism is none of the above
+            rule:
+                column: organism_ontology_term_id
+                exclude_ancestors_inclusive:
+                  ancestors:
+                    - NCBITaxon:10090
+                exclude_exact:
+                  terms:
+                    - NCBITaxon:6239
+                    - NCBITaxon:7955
+                    - NCBITaxon:7227
+                    - NCBITaxon:9606
+            error_message_suffix: >-
+              When 'organism_ontology_term_id'-specific requirements are not defined in the schema definition, 'development_stage_ontology_term_id' MUST be a descendant term id of 'UBERON:0000105' excluding 'UBERON:0000071', 'na', or unknown.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - UBERON
+              allowed:
+                ancestors:
+                  UBERON:
+                    - UBERON:0000105
+              exceptions:
+                - unknown
+                - na
+              forbidden:
+                terms:
+                  - UBERON:0000071
+          - # If tissue_type is "cell line", development_stage_ontology_term_id must be "na"
+            rule:
+              column: tissue_type
+              match_exact:
+                terms:
+                  - cell line
+            error_message_suffix: >-
+              When 'tissue_type' is 'cell line', 'development_stage_ontology_term_id' MUST be 'na'.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - NA
+              exceptions:
+                - na
+          - # If tissue_type is not "cell line", development_stage_ontology_term_id cannot be "na"
+            rule:
+              column: tissue_type
+              exclude_exact:
+                terms:
+                  - cell line
+            error_message_suffix: >-
+              When 'tissue_type' is not 'cell line', 'development_stage_ontology_term_id' cannot be 'na'.
+            type: curie
+            curie_constraints:
+              ontologies:
+                - UBERON
+                - HsapDv
+                - MmusDv
+                - ZFA
+                - ZFS
+                - FBdv
+                - WBls
+              exceptions:
+                - unknown
+              forbidden:
+                terms:
+                  - na
+        add_labels:
+          - type: curie
+            to_column: development_stage
+      is_primary_data:
+        type: bool
+      donor_id:
+        type: categorical
+        subtype: str
+        forbidden:
+          - na
+        dependencies:
+          - # If tissue_type is "cell line", donor_id must be "na"
+            rule:
+              column: tissue_type
+              match_exact:
+                terms:
+                  - cell line
+            error_message_suffix: >-
+              when 'tissue_type' is 'cell line'.
+            type: categorical
+            subtype: str
+            enum:
+              - na
+      suspension_type:
+        type: categorical
+        enum:
+          - "cell"
+          - "nucleus"
+          - "na"
+        error_message_suffix: >-
+          when 'assay_ontology_term_id' does not match one of the assays in the schema definition.
+        # if no dependencies are matched
+        warning_message: >-
+          Data contains assay(s) that are not represented in the 'suspension_type' schema definition table. Ensure you have
+          selected the most appropriate value for the assay(s) between 'cell', 'nucleus', and 'na'. Please contact cellxgene@chanzuckerberg.com
+          during submission so that the assay(s) can be added to the schema definition document.
+        dependencies:
+          - # 'suspension_type' MUST be 'cell' or 'nucleus'
+            rule:
+              column: assay_ontology_term_id
+              match_ancestors_inclusive:
+                ancestors:
+                  - EFO:0030080
+                  - EFO:0010184
+                  - EFO:0010010
+                  - EFO:0009919
+              match_exact:
+                terms:
+                  - EFO:0008722
+                  - EFO:0008780
+                  - EFO:0700010
+                  - EFO:0700011
+                  - EFO:0030060
+                  - EFO:0022490
+                  - EFO:0030028
+            type: categorical
+            enum:
+              - "cell"
+              - "nucleus"
+          - # 'suspension_type' MUST be 'nucleus'
+            rule:
+              column: assay_ontology_term_id
+              match_ancestors_inclusive:
+                ancestors:
+                  - EFO:0007045
+                  - EFO:0002761
+              match_exact:
+                terms:
+                  - EFO:0008720
+                  - EFO:0030026
+            type: categorical
+            enum:
+              - "nucleus"
+          - #'suspension_type' MUST be 'cell'
+            rule:
+              column: assay_ontology_term_id
+              match_ancestors_inclusive:
+                ancestors:
+                  - EFO:0008919
+                  - EFO:0008853
+                  - EFO:0008953
+              match_exact:
+                terms:
+                  - EFO:0030002
+                  - EFO:0008796
+                  - EFO:0700003
+                  - EFO:0700004
+                  - EFO:0008679
+                  - EFO:0008877
+            type: categorical
+            enum:
+              - "cell"
+          - # 'suspension_type' MUST be 'na'
+            rule:
+              column: assay_ontology_term_id
+              match_ancestors_inclusive:
+                ancestors:
+                  - EFO:0008994
+              match_exact:
+                terms:
+                  - EFO:0008992
+            type: categorical
+            enum:
+              - "na"
+      tissue_type:
+        type: categorical
+        enum:
+          - "primary cell culture"
+          - "organoid"
+          - "tissue"
+          - "cell line"
+      organism_ontology_term_id:
+        type: curie
+        required: True
+        curie_constraints:
+          ontologies:
+            - NCBITaxon
+          allowed:
+            terms:
+              NCBITaxon:
+                - NCBITaxon:9606
+                - NCBITaxon:10090
+                - NCBITaxon:7227
+                - NCBITaxon:7955
+                - NCBITaxon:6239
+                - NCBITaxon:9541
+                - NCBITaxon:9986
+                - NCBITaxon:9483
+                - NCBITaxon:9595
+                - NCBITaxon:9544
+                - NCBITaxon:9598
+                - NCBITaxon:9823
+                - NCBITaxon:30608
+                - NCBITaxon:10116
+            ancestors:
+              NCBITaxon:
+                - NCBITaxon:9541
+                - NCBITaxon:9544
+                - NCBITaxon:10090
+                - NCBITaxon:9986
+                - NCBITaxon:9598
+                - NCBITaxon:10116
+                - NCBITaxon:9823
+          forbidden:
+            terms:
+              - NCBITaxon:2697049
+              - NCBITaxon:32630
+        add_labels:
+          - type: curie
+            to_column: organism

--- a/hca_schema_validator/src/hca_schema_validator/validator.py
+++ b/hca_schema_validator/src/hca_schema_validator/validator.py
@@ -1,6 +1,6 @@
 """HCA Validator - extends cellxgene Validator with HCA-specific rules."""
 
-import os
+from pathlib import Path
 import yaml
 
 from cellxgene_schema.validate import Validator
@@ -37,12 +37,7 @@ class HCAValidator(Validator):
         
         if not self.schema_def:
             # Load HCA-specific schema
-            package_root = os.path.dirname(os.path.realpath(__file__))
-            schema_path = os.path.join(
-                package_root, 
-                "schema_definitions", 
-                "hca_schema_definition.yaml"
-            )
+            schema_path = Path(__file__).parent / "schema_definitions" / "hca_schema_definition.yaml"
             
             with open(schema_path) as fp:
                 self.schema_def = yaml.load(fp, Loader=yaml.FullLoader)

--- a/hca_schema_validator/src/hca_schema_validator/validator.py
+++ b/hca_schema_validator/src/hca_schema_validator/validator.py
@@ -1,14 +1,18 @@
 """HCA Validator - extends cellxgene Validator with HCA-specific rules."""
 
+import os
+import yaml
+
 from cellxgene_schema.validate import Validator
+from . import __schema_version__ as HCA_SCHEMA_VERSION
 
 
 class HCAValidator(Validator):
     """
     HCA-specific validator extending cellxgene schema validation.
     
-    Currently a passthrough to the base Validator.
-    Future enhancements will add HCA-specific validation rules.
+    Uses a custom schema definition that differs from CELLxGENE in key areas:
+    - organism and organism_ontology_term_id are in obs (not uns)
     """
     
     def __init__(self, ignore_labels=False):
@@ -19,3 +23,26 @@ class HCAValidator(Validator):
             ignore_labels: If True, skip label validation
         """
         super().__init__(ignore_labels=ignore_labels)
+    
+    def _set_schema_def(self):
+        """
+        Sets schema dictionary using HCA-specific schema definition.
+        
+        Overrides the base method to load HCA's custom schema instead of
+        the default CELLxGENE schema.
+        """
+        if not self.schema_version:
+            # Use HCA schema version
+            self.schema_version = HCA_SCHEMA_VERSION
+        
+        if not self.schema_def:
+            # Load HCA-specific schema
+            package_root = os.path.dirname(os.path.realpath(__file__))
+            schema_path = os.path.join(
+                package_root, 
+                "schema_definitions", 
+                "hca_schema_definition.yaml"
+            )
+            
+            with open(schema_path) as fp:
+                self.schema_def = yaml.load(fp, Loader=yaml.FullLoader)

--- a/hca_schema_validator/src/hca_schema_validator/validator.py
+++ b/hca_schema_validator/src/hca_schema_validator/validator.py
@@ -44,4 +44,4 @@ class HCAValidator(Validator):
             schema_path = Path(__file__).parent / SCHEMA_DIR / SCHEMA_FILENAME
             
             with open(schema_path) as fp:
-                self.schema_def = yaml.load(fp, Loader=yaml.FullLoader)
+                self.schema_def = yaml.safe_load(fp)

--- a/hca_schema_validator/src/hca_schema_validator/validator.py
+++ b/hca_schema_validator/src/hca_schema_validator/validator.py
@@ -6,6 +6,10 @@ import yaml
 from cellxgene_schema.validate import Validator
 from . import __schema_version__ as HCA_SCHEMA_VERSION
 
+# Schema file constants
+SCHEMA_DIR = "schema_definitions"
+SCHEMA_FILENAME = "hca_schema_definition.yaml"
+
 
 class HCAValidator(Validator):
     """
@@ -37,7 +41,7 @@ class HCAValidator(Validator):
         
         if not self.schema_def:
             # Load HCA-specific schema
-            schema_path = Path(__file__).parent / "schema_definitions" / "hca_schema_definition.yaml"
+            schema_path = Path(__file__).parent / SCHEMA_DIR / SCHEMA_FILENAME
             
             with open(schema_path) as fp:
                 self.schema_def = yaml.load(fp, Loader=yaml.FullLoader)

--- a/hca_schema_validator/tests/fixtures/hca_fixtures.py
+++ b/hca_schema_validator/tests/fixtures/hca_fixtures.py
@@ -1,0 +1,663 @@
+# flake8: noqa
+# HCA VERSION: organism_ontology_term_id in obs (not uns)
+import pandas as pd
+import numpy
+import anndata
+import os
+from scipy import sparse
+from cellxgene_schema.utils import get_hash_digest_column
+from dask.array import from_array
+
+# -----------------------------------------------------------------#
+# General example information
+FIXTURES_ROOT = os.path.join(os.path.dirname(__file__))
+
+# -----------------------------------------------------------------#
+# Pre-made example files
+h5ad_dir = os.path.join(FIXTURES_ROOT, "h5ads")
+h5ad_valid = os.path.join(h5ad_dir, "example_valid.h5ad")
+h5ad_invalid = os.path.join(h5ad_dir, "example_invalid_CL.h5ad")
+
+# -----------------------------------------------------------------#
+# Manually creating minimal anndata objects.
+#
+# The valid objects mentioned below contain all valid cases covered in the schema, including multiple examples for
+# fields that allow multiple valid options.
+#
+# This process entails:
+# 1. Creating individual obs components: one valid dataframe, and one with labels (extra columns that are supposed
+#   to be added by validator)
+# 2. Creating individual var components: valid, and one with labels
+# 3. Creating individual uns valid component
+# 4. Creating expression matrices
+# 5. Creating valid obsm
+# 6. Putting all the components created in the previous steps into minimal anndata that used for testing in
+#   the unittests
+
+# Valid obs per schema
+good_obs = pd.DataFrame(
+    [
+        [
+            "CL:0000066",
+            "EFO:0009899",
+            "MONDO:0100096",
+            "PATO:0000383",
+            "UBERON:0002048",
+            "tissue",
+            True,
+            "HANCESTRO:0019",
+            "HsapDv:0000003",
+            "donor_1",
+            "nucleus",
+            "NCBITaxon:9606",  # HCA: organism in obs
+        ],
+        [
+            "CL:0000066",
+            "EFO:0009899",
+            "MONDO:0100096",
+            "PATO:0000383",
+            "UBERON:0002048",
+            "tissue",
+            True,
+            "HANCESTRO:0019",
+            "HsapDv:0000003",
+            "donor_1",
+            "nucleus",
+            "NCBITaxon:9606",  # HCA: organism in obs
+        ],
+    ],
+    index=["X", "Y"],
+    columns=[
+        "cell_type_ontology_term_id",
+        "assay_ontology_term_id",
+        "disease_ontology_term_id",
+        "sex_ontology_term_id",
+        "tissue_ontology_term_id",
+        "tissue_type",
+        "is_primary_data",
+        "self_reported_ethnicity_ontology_term_id",
+        "development_stage_ontology_term_id",
+        "donor_id",
+        "suspension_type",
+        "organism_ontology_term_id",  # HCA: organism in obs
+    ],
+)
+
+good_obs["donor_id"] = good_obs["donor_id"].astype("category")
+good_obs["suspension_type"] = good_obs["suspension_type"].astype("category")
+good_obs["tissue_type"] = good_obs["tissue_type"].astype("category")
+good_obs["tissue_type"] = good_obs["tissue_type"].cat.add_categories(["primary cell culture", "organoid", "cell line"])
+
+# Expected obs, this is what the obs above should look like after adding the necessary columns with the validator,
+# these columns are defined in the schema
+obs_expected = pd.DataFrame(
+    [
+        [
+            "epithelial cell",
+            "10x 3' v2",
+            "COVID-19",
+            "female",
+            "lung",
+            "Japanese",
+            "Carnegie stage 01",
+        ],
+        [
+            "epithelial cell",
+            "10x 3' v2",
+            "COVID-19",
+            "female",
+            "lung",
+            "Japanese",
+            "Carnegie stage 01",
+        ],
+    ],
+    index=["X", "Y"],
+    columns=[
+        "cell_type",
+        "assay",
+        "disease",
+        "sex",
+        "tissue",
+        "self_reported_ethnicity",
+        "development_stage",
+    ],
+)
+
+obs_expected["observation_joinid"] = get_hash_digest_column(obs_expected)
+
+# Valid spatial obs per schema
+good_obs_visium = pd.DataFrame(
+    [
+        [
+            1,
+            1,
+            "unknown",
+            "EFO:0022859",
+            "MONDO:0100096",
+            "PATO:0000383",
+            "UBERON:0002048",
+            "tissue",
+            True,
+            "HANCESTRO:0019",
+            "HsapDv:0000003",
+            "donor_1",
+            "na",
+            0,
+        ],
+        [
+            1,
+            1,
+            "unknown",
+            "EFO:0022859",
+            "MONDO:0100096",
+            "PATO:0000383",
+            "UBERON:0002048",
+            "tissue",
+            True,
+            "HANCESTRO:0019",
+            "HsapDv:0000003",
+            "donor_1",
+            "na",
+            1,
+        ],
+    ],
+    index=["X", "Y"],
+    columns=[
+        "array_col",
+        "array_row",
+        "cell_type_ontology_term_id",
+        "assay_ontology_term_id",
+        "disease_ontology_term_id",
+        "sex_ontology_term_id",
+        "tissue_ontology_term_id",
+        "tissue_type",
+        "is_primary_data",
+        "self_reported_ethnicity_ontology_term_id",
+        "development_stage_ontology_term_id",
+        "donor_id",
+        "suspension_type",
+        "in_tissue",
+    ],
+)
+
+good_obs_visium["donor_id"] = good_obs_visium["donor_id"].astype("category")
+good_obs_visium["suspension_type"] = good_obs_visium["suspension_type"].astype("category")
+good_obs_visium["tissue_type"] = good_obs_visium["tissue_type"].astype("category")
+good_obs_visium["tissue_type"] = good_obs_visium["tissue_type"].cat.add_categories(
+    ["primary cell culture", "organoid", "cell line"]
+)
+
+# Valid spatial obs per schema
+good_obs_slide_seqv2 = pd.DataFrame(
+    [
+        [
+            "CL:0000066",
+            "EFO:0030062",
+            "MONDO:0100096",
+            "PATO:0000383",
+            "UBERON:0002048",
+            "tissue",
+            True,
+            "HANCESTRO:0019",
+            "HsapDv:0000003",
+            "donor_1",
+            "na",
+        ],
+        [
+            "CL:0000066",
+            "EFO:0030062",
+            "MONDO:0100096",
+            "PATO:0000383",
+            "UBERON:0002048",
+            "tissue",
+            True,
+            "HANCESTRO:0019",
+            "HsapDv:0000003",
+            "donor_1",
+            "na",
+        ],
+    ],
+    index=["X", "Y"],
+    columns=[
+        "cell_type_ontology_term_id",
+        "assay_ontology_term_id",
+        "disease_ontology_term_id",
+        "sex_ontology_term_id",
+        "tissue_ontology_term_id",
+        "tissue_type",
+        "is_primary_data",
+        "self_reported_ethnicity_ontology_term_id",
+        "development_stage_ontology_term_id",
+        "donor_id",
+        "suspension_type",
+    ],
+)
+
+good_obs_slide_seqv2["donor_id"] = good_obs_slide_seqv2["donor_id"].astype("category")
+good_obs_slide_seqv2["suspension_type"] = good_obs_slide_seqv2["suspension_type"].astype("category")
+good_obs_slide_seqv2["tissue_type"] = good_obs_slide_seqv2["tissue_type"].astype("category")
+good_obs_slide_seqv2["tissue_type"] = good_obs_slide_seqv2["tissue_type"].cat.add_categories(
+    ["primary cell culture", "organoid", "cell line"]
+)
+
+good_obs_visium_is_single_false = pd.DataFrame(
+    [
+        [
+            "CL:0000066",
+            "EFO:0022859",
+            "MONDO:0100096",
+            "PATO:0000383",
+            "UBERON:0002048",
+            "tissue",
+            False,
+            "HANCESTRO:0019",
+            "HsapDv:0000003",
+            "donor_1",
+            "na",
+        ],
+        [
+            "CL:0000066",
+            "EFO:0022859",
+            "MONDO:0100096",
+            "PATO:0000383",
+            "UBERON:0002048",
+            "tissue",
+            False,
+            "HANCESTRO:0019",
+            "HsapDv:0000003",
+            "donor_1",
+            "na",
+        ],
+    ],
+    index=["X", "Y"],
+    columns=[
+        "cell_type_ontology_term_id",
+        "assay_ontology_term_id",
+        "disease_ontology_term_id",
+        "sex_ontology_term_id",
+        "tissue_ontology_term_id",
+        "tissue_type",
+        "is_primary_data",
+        "self_reported_ethnicity_ontology_term_id",
+        "development_stage_ontology_term_id",
+        "donor_id",
+        "suspension_type",
+    ],
+)
+
+good_obs_visium_is_single_false["donor_id"] = good_obs_visium_is_single_false["donor_id"].astype("category")
+good_obs_visium_is_single_false["suspension_type"] = good_obs_visium_is_single_false["suspension_type"].astype(
+    "category"
+)
+good_obs_visium_is_single_false["tissue_type"] = good_obs_visium_is_single_false["tissue_type"].astype("category")
+good_obs_visium_is_single_false["tissue_type"] = good_obs_visium_is_single_false["tissue_type"].cat.add_categories(
+    ["primary cell culture", "organoid", "cell line"]
+)
+
+good_obs_mouse = pd.DataFrame(
+    [
+        [
+            "CL:0000192",
+            "EFO:0008992",
+            "PATO:0000461",
+            "unknown",
+            "CL:0000192",
+            "primary cell culture",
+            False,
+            "na",
+            "MmusDv:0000003",
+            "donor_2",
+            "na",
+            "NCBITaxon:10090",  # HCA: organism in obs
+        ],
+        [
+            "CL:0000192",
+            "EFO:0008992",
+            "PATO:0000461",
+            "unknown",
+            "CL:0000192",
+            "primary cell culture",
+            False,
+            "na",
+            "MmusDv:0000003",
+            "donor_2",
+            "na",
+            "NCBITaxon:10090",  # HCA: organism in obs
+        ],
+    ],
+    index=["X", "Y"],
+    columns=[
+        "cell_type_ontology_term_id",
+        "assay_ontology_term_id",
+        "disease_ontology_term_id",
+        "sex_ontology_term_id",
+        "tissue_ontology_term_id",
+        "tissue_type",
+        "is_primary_data",
+        "self_reported_ethnicity_ontology_term_id",
+        "development_stage_ontology_term_id",
+        "donor_id",
+        "suspension_type",
+        "organism_ontology_term_id",  # HCA: organism in obs
+    ],
+)
+
+good_obs_mouse["donor_id"] = good_obs_mouse["donor_id"].astype("category")
+good_obs_mouse["suspension_type"] = good_obs_mouse["suspension_type"].astype("category")
+good_obs_mouse["tissue_type"] = good_obs_mouse["tissue_type"].astype("category")
+good_obs_mouse["tissue_type"] = good_obs_mouse["tissue_type"].cat.add_categories(["tissue", "organoid", "cell line"])
+
+# Creating a cell line obs by copying good_obs and changing the necessary fields
+good_obs_cell_line = good_obs.copy()
+good_obs_cell_line.loc[:, "tissue_type"] = "cell line"
+good_obs_cell_line.loc[:, "tissue_ontology_term_id"] = "CVCL_0001"
+good_obs_cell_line.loc[:, "development_stage_ontology_term_id"] = "na"
+good_obs_cell_line.loc[:, "sex_ontology_term_id"] = "na"
+good_obs_cell_line.loc[:, "self_reported_ethnicity_ontology_term_id"] = "na"
+good_obs_cell_line.loc[:, "donor_id"] = "na"
+good_obs_cell_line["donor_id"] = good_obs_cell_line["donor_id"].astype("category")
+
+# ---
+# 2. Creating individual var components: valid object and valid object and with labels
+
+# Valid var per schema
+good_var = pd.DataFrame(
+    [[False]],
+    index=[
+        "ENSG00000127603",
+        "ENSG00000141510",
+        "ENSG00000012048",
+        "ENSG00000139618",
+        "ENSG00000002330",
+        "ENSG00000000005",
+        "ENSG00000000419",
+    ],
+    columns=["feature_is_filtered"],
+)
+good_var_mouse = pd.DataFrame(
+    [[False]],
+    index=[
+        "ENSMUSG00000102693",
+        "ENSMUSG00000064842",
+        "ENSMUSG00000051951",
+        "ENSMUSG00000102851",
+        "ENSMUSG00000103377",
+        "ENSMUSG00000104017",
+        "ENSMUSG00000103025",
+    ],
+    columns=["feature_is_filtered"],
+)
+
+# Expected var, this is what the obs above should look like after adding the necessary columns with the validator,
+# these columns are defined in the schema
+var_expected = pd.DataFrame(
+    [
+        ["gene", False, "MACF1", "NCBITaxon:9606", 2821, "protein_coding"],
+        ["gene", False, "TP53", "NCBITaxon:9606", 2426, "protein_coding"],
+        ["gene", False, "BRCA1", "NCBITaxon:9606", 3757, "protein_coding"],
+        ["gene", False, "BRCA2", "NCBITaxon:9606", 11428, "protein_coding"],
+        ["gene", False, "BAD", "NCBITaxon:9606", 552, "protein_coding"],
+        ["gene", False, "TNMD", "NCBITaxon:9606", 873, "protein_coding"],
+        ["gene", False, "DPM1", "NCBITaxon:9606", 1262, "protein_coding"],
+    ],
+    index=[
+        "ENSG00000127603",
+        "ENSG00000141510",
+        "ENSG00000012048",
+        "ENSG00000139618",
+        "ENSG00000002330",
+        "ENSG00000000005",
+        "ENSG00000000419",
+    ],
+    columns=[
+        "feature_biotype",
+        "feature_is_filtered",
+        "feature_name",
+        "feature_reference",
+        "feature_length",
+        "feature_type",
+    ],
+)
+
+NUMBER_OF_GENES = len(var_expected.index)
+
+# ---
+# 3. Creating individual uns component
+# HCA: organism_ontology_term_id NOT in uns (it's in obs)
+good_uns = {
+    "title": "A title",
+    "default_embedding": "X_umap",
+    "X_approximate_distribution": "normal",
+    "batch_condition": ["is_primary_data"],
+}
+
+# HCA: organism_ontology_term_id NOT in uns (it's in obs)
+good_uns_mouse = {
+    "title": "A title",
+    "default_embedding": "X_umap",
+    "X_approximate_distribution": "normal",
+    "batch_condition": ["is_primary_data"],
+}
+
+good_uns_with_labels = {
+    "organism_ontology_term_id": "NCBITaxon:9606",
+    "organism": "Homo sapiens",
+    "schema_version": "4.0.0",
+    "schema_reference": "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/4.0.0/schema.md",
+    "citation": "Publication: <doi> Dataset Version: "
+    "https://datasets.cellxgene.cziscience.com/<dataset_version_id>.h5ad curated and distributed by CZ "
+    "CELLxGENE Discover in Collection: https://cellxgene.cziscience.com/collections/<collection_id>",
+    "title": "A title",
+    "default_embedding": "X_umap",
+    "X_approximate_distribution": "normal",
+    "batch_condition": ["is_primary_data"],
+}
+
+good_uns_with_colors = {
+    "organism_ontology_term_id": "NCBITaxon:9606",
+    "title": "A title",
+    "default_embedding": "X_umap",
+    "X_approximate_distribution": "normal",
+    "batch_condition": ["is_primary_data"],
+    "suspension_type_colors": numpy.array(["red", "blue"]),
+    "donor_id_colors": numpy.array(["#000000", "#ffffff"]),
+    "tissue_type_colors": numpy.array(["black", "pink"]),
+}
+
+visium_library_id = "Proj2023_Lung_C001"
+
+good_uns_with_visium_spatial = {
+    "organism_ontology_term_id": "NCBITaxon:9606",
+    "title": "A title",
+    "default_embedding": "X_umap",
+    "X_approximate_distribution": "normal",
+    "batch_condition": ["is_primary_data"],
+    "spatial": {
+        "is_single": numpy.bool_(True),
+        visium_library_id: {
+            "images": {
+                "hires": numpy.zeros((2000, 100, 3), dtype=numpy.uint8),
+                "fullres": numpy.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]], dtype=numpy.uint8),
+            },
+            "scalefactors": {
+                "spot_diameter_fullres": 1.0,
+                "tissue_hires_scalef": 1.0,
+            },
+        },
+    },
+}
+
+good_uns_with_is_single_false = {
+    "organism_ontology_term_id": "NCBITaxon:9606",
+    "title": "A title",
+    "default_embedding": "X_umap",
+    "X_approximate_distribution": "normal",
+    "batch_condition": ["is_primary_data"],
+    "spatial": {"is_single": False},
+}
+
+good_uns_with_slide_seqV2_spatial = {
+    "organism_ontology_term_id": "NCBITaxon:9606",
+    "title": "A title",
+    "default_embedding": "X_umap",
+    "X_approximate_distribution": "normal",
+    "batch_condition": ["is_primary_data"],
+    "spatial": {"is_single": True},
+}
+
+# ---
+# 4. Creating expression matrix,
+# X has integer values and non_raw_X has real values
+X = from_array(sparse.csr_matrix((good_obs.shape[0], good_var.shape[0]), dtype=numpy.float32))
+for i in range(good_obs.shape[0]):
+    for j in range(good_var.shape[0]):
+        X[i, j] = i + j
+non_raw_X = X.copy()
+non_raw_X[0, 0] = 1.5
+
+# ---
+# 5.Creating valid obsm
+good_obsm = {"X_umap": numpy.zeros([X.shape[0], 2])}
+good_obsm_spatial = {"X_umap": numpy.zeros([X.shape[0], 2]), "spatial": numpy.zeros([X.shape[0], 2])}
+
+# ---
+# 6. Putting all the components created in the previous steps into minimal anndata that used for testing in
+#   the unittests
+
+# Valid anndata
+adata = anndata.AnnData(X=X.copy(), obs=good_obs, uns=good_uns, obsm=good_obsm, var=good_var)
+adata.raw = adata.copy()
+adata.X = non_raw_X
+adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# Anndata with "X" and "raw.X" but neither has actual raw values
+adata_no_raw_values = anndata.AnnData(
+    X=non_raw_X.copy(),
+    obs=good_obs,
+    uns=good_uns,
+    obsm=good_obsm,
+    var=good_var,
+)
+adata_no_raw_values.raw = adata_no_raw_values.copy()
+adata_no_raw_values.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# Anndata with no obs nor var
+adata_minimal = anndata.AnnData(X=X.copy(), uns=good_uns, obsm=good_obsm)
+
+# Anndata with a expression matrix that is not raw g
+adata_non_raw = anndata.AnnData(
+    X=non_raw_X.copy(),
+    obs=good_obs,
+    uns=good_uns,
+    obsm=good_obsm,
+    var=good_var,
+)
+
+# Expected anndata with labels that the validator must write in obs and var
+adata_with_labels = anndata.AnnData(
+    X=X.copy(),
+    obs=pd.concat([good_obs, obs_expected], axis=1),
+    var=var_expected,
+    uns=good_uns_with_labels,
+    obsm=good_obsm,
+)
+
+# Expected anndata with colors for categorical obs fields
+adata_with_colors = anndata.AnnData(X=X.copy(), obs=good_obs, uns=good_uns_with_colors, obsm=good_obsm, var=good_var)
+
+# Expected anndata with Visium spatial data
+adata_visium = anndata.AnnData(
+    X=X.copy(), obs=good_obs_visium, uns=good_uns_with_visium_spatial, obsm=good_obsm_spatial, var=good_var
+)
+adata_visium.raw = adata_visium.copy()
+adata_visium.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+# Expected anndata with Slide-seqV2 spatial data
+adata_slide_seqv2 = anndata.AnnData(
+    X=X.copy(),
+    obs=good_obs_slide_seqv2,
+    uns=good_uns_with_slide_seqV2_spatial,
+    obsm=good_obsm_spatial,
+    var=good_var,
+)
+
+adata_spatial_is_single_false = anndata.AnnData(
+    X=X.copy(),
+    obs=good_obs_visium_is_single_false,
+    uns=good_uns_with_is_single_false,
+    obsm=good_obsm_spatial,
+    var=good_var,
+)
+
+adata_mouse = anndata.AnnData(
+    X=X.copy(),
+    obs=good_obs_mouse,
+    uns=good_uns_mouse,
+    obsm=good_obsm,
+    var=good_var_mouse,
+)
+
+# Expected anndata with cell line data
+adata_with_cell_line = anndata.AnnData(
+    X=X.copy(),
+    obs=good_obs_cell_line,
+    uns=good_uns,  # Use human organism since we test with human development stage terms
+    obsm=good_obsm,
+    var=good_var,  # Use human feature IDs since we're using human organism
+)
+
+# anndata for testing migration
+unmigrated_obs = pd.DataFrame(
+    [
+        [
+            "cell_type:1",
+            "assay:1",
+            "disease:1",
+            "sex:1",
+            "tissue:1",
+            "sre:1",
+            "development_stage:1",
+        ],
+        [
+            "cell_type:1",
+            "assay:1",
+            "disease:1",
+            "sex:1",
+            "tissue:1",
+            "sre:1",
+            "development_stage:1",
+        ],
+    ],
+    index=["X", "Y"],
+    columns=[
+        "cell_type_ontology_term_id",
+        "assay_ontology_term_id",
+        "disease_ontology_term_id",
+        "sex_ontology_term_id",
+        "tissue_ontology_term_id",
+        "self_reported_ethnicity_ontology_term_id",
+        "development_stage_ontology_term_id",
+    ],
+)
+
+var_unmigrated = pd.DataFrame(
+    [
+        [False],
+        [False],
+    ],
+    index=["ENSSASG00005000004", "DUMMY"],
+    columns=[
+        "feature_is_filtered",
+    ],
+)
+
+unmigrated_X = sparse.csr_matrix(numpy.zeros([unmigrated_obs.shape[0], var_unmigrated.shape[0]], dtype=numpy.float32))
+
+adata_with_labels_unmigrated = anndata.AnnData(
+    X=unmigrated_X.copy(),
+    obs=unmigrated_obs,
+    uns=good_uns_with_labels,
+    var=var_unmigrated,
+    obsm={"X_umap": numpy.zeros([unmigrated_X.shape[0], 2])},
+)
+adata_with_labels_unmigrated.raw = adata_with_labels_unmigrated.copy()

--- a/hca_schema_validator/tests/test_validator.py
+++ b/hca_schema_validator/tests/test_validator.py
@@ -1,5 +1,6 @@
 """Tests for HCA Validator."""
 
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -44,7 +45,12 @@ def test_has_validation_methods():
 
 
 def test_validate_valid_h5ad():
-    """Test validation of a valid h5ad file."""
+    """
+    Test validation of a CELLxGENE v6+ h5ad file.
+    
+    This test verifies that HCA schema correctly rejects CELLxGENE v6+ files
+    that have organism in uns instead of obs.
+    """
     test_file = FIXTURES_DIR / "example_valid.h5ad"
     
     if not test_file.exists():
@@ -53,11 +59,13 @@ def test_validate_valid_h5ad():
     validator = HCAValidator()
     is_valid = validator.validate_adata(str(test_file))
     
-    # Should pass validation
-    assert is_valid is True
-    assert len(validator.errors) == 0
-    # May have warnings (that's okay)
-    assert validator.warnings is not None
+    # Should FAIL validation because CELLxGENE v6+ files have organism in uns,
+    # but HCA schema requires it in obs
+    assert is_valid is False
+    assert len(validator.errors) > 0
+    # Should have an error about missing organism_ontology_term_id in obs
+    error_messages = " ".join(validator.errors)
+    assert "organism_ontology_term_id" in error_messages.lower()
 
 
 def test_validate_invalid_h5ad():
@@ -73,3 +81,33 @@ def test_validate_invalid_h5ad():
     # Should fail validation
     assert is_valid is False
     assert len(validator.errors) > 0
+
+
+def test_organism_in_obs():
+    """
+    Test that HCA schema accepts organism_ontology_term_id in obs.
+    
+    This is the HCA requirement - organism fields should be in obs, not uns
+    (reverting the CELLxGENE v6 change that moved them to uns).
+    """
+    from tests.fixtures.hca_fixtures import adata
+    
+    # Create a temporary h5ad file
+    with tempfile.NamedTemporaryFile(suffix=".h5ad", delete=False) as tmp:
+        tmp_path = tmp.name
+        adata.write_h5ad(tmp_path)
+    
+    try:
+        validator = HCAValidator()
+        is_valid = validator.validate_adata(tmp_path)
+        
+        # HCA requirement: Should accept organism_ontology_term_id in obs
+        assert is_valid is True, f"Validation failed with errors: {validator.errors}"
+        
+        # Should not have errors about organism being in obs
+        for error in validator.errors:
+            assert "organism" not in error.lower() or "deprecated" not in error.lower(), \
+                "organism_ontology_term_id should not be deprecated in obs for HCA schema"
+    finally:
+        # Cleanup
+        Path(tmp_path).unlink(missing_ok=True)

--- a/hca_schema_validator/tests/test_validator.py
+++ b/hca_schema_validator/tests/test_validator.py
@@ -1,6 +1,5 @@
 """Tests for HCA Validator."""
 
-import os
 import tempfile
 from pathlib import Path
 
@@ -93,14 +92,13 @@ def test_organism_in_obs():
     """
     from .fixtures.hca_fixtures import adata
     
-    # Create a temporary h5ad file using mkstemp for better resource management
-    fd, tmp_path = tempfile.mkstemp(suffix=".h5ad")
-    try:
-        os.close(fd)  # Close the file descriptor immediately
-        adata.write_h5ad(tmp_path)
+    # Use TemporaryDirectory for automatic cleanup
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir) / "test.h5ad"
+        adata.write_h5ad(str(tmp_path))
         
         validator = HCAValidator()
-        is_valid = validator.validate_adata(tmp_path)
+        is_valid = validator.validate_adata(str(tmp_path))
         
         # HCA requirement: Should accept organism_ontology_term_id in obs
         assert is_valid is True, f"Validation failed with errors: {validator.errors}"
@@ -109,6 +107,3 @@ def test_organism_in_obs():
         for error in validator.errors:
             assert not ("organism" in error.lower() and "deprecated" in error.lower()), \
                 "organism_ontology_term_id should not be deprecated in obs for HCA schema"
-    finally:
-        # Cleanup - always executed even if test fails
-        Path(tmp_path).unlink(missing_ok=True)

--- a/hca_schema_validator/tests/test_validator.py
+++ b/hca_schema_validator/tests/test_validator.py
@@ -90,7 +90,7 @@ def test_organism_in_obs():
     This is the HCA requirement - organism fields should be in obs, not uns
     (reverting the CELLxGENE v6 change that moved them to uns).
     """
-    from tests.fixtures.hca_fixtures import adata
+    from .fixtures.hca_fixtures import adata
     
     # Create a temporary h5ad file
     with tempfile.NamedTemporaryFile(suffix=".h5ad", delete=False) as tmp:
@@ -104,9 +104,9 @@ def test_organism_in_obs():
         # HCA requirement: Should accept organism_ontology_term_id in obs
         assert is_valid is True, f"Validation failed with errors: {validator.errors}"
         
-        # Should not have errors about organism being in obs
+        # Should not have errors about organism being deprecated in obs
         for error in validator.errors:
-            assert "organism" not in error.lower() or "deprecated" not in error.lower(), \
+            assert not ("organism" in error.lower() and "deprecated" in error.lower()), \
                 "organism_ontology_term_id should not be deprecated in obs for HCA schema"
     finally:
         # Cleanup

--- a/hca_schema_validator/tests/test_validator.py
+++ b/hca_schema_validator/tests/test_validator.py
@@ -1,5 +1,6 @@
 """Tests for HCA Validator."""
 
+import os
 import tempfile
 from pathlib import Path
 
@@ -92,12 +93,12 @@ def test_organism_in_obs():
     """
     from .fixtures.hca_fixtures import adata
     
-    # Create a temporary h5ad file
-    with tempfile.NamedTemporaryFile(suffix=".h5ad", delete=False) as tmp:
-        tmp_path = tmp.name
-        adata.write_h5ad(tmp_path)
-    
+    # Create a temporary h5ad file using mkstemp for better resource management
+    fd, tmp_path = tempfile.mkstemp(suffix=".h5ad")
     try:
+        os.close(fd)  # Close the file descriptor immediately
+        adata.write_h5ad(tmp_path)
+        
         validator = HCAValidator()
         is_valid = validator.validate_adata(tmp_path)
         
@@ -109,5 +110,5 @@ def test_organism_in_obs():
             assert not ("organism" in error.lower() and "deprecated" in error.lower()), \
                 "organism_ontology_term_id should not be deprecated in obs for HCA schema"
     finally:
-        # Cleanup
+        # Cleanup - always executed even if test fails
         Path(tmp_path).unlink(missing_ok=True)

--- a/hca_schema_validator/validate_file.py
+++ b/hca_schema_validator/validate_file.py
@@ -6,7 +6,7 @@ Usage:
     poetry run python validate_file.py <path/to/file.h5ad>
     poetry run python validate_file.py <path/to/file.h5ad> --with-labels
 """
-import sys
+import argparse
 from hca_schema_validator import HCAValidator
 
 # Display constants
@@ -14,15 +14,28 @@ SEPARATOR_WIDTH = 70
 
 def main():
     # Parse command-line arguments
-    if len(sys.argv) < 2:
-        print("Error: Please provide a file path")
-        print("\nUsage:")
-        print("  poetry run python validate_file.py <path/to/file.h5ad>")
-        print("  poetry run python validate_file.py <path/to/file.h5ad> --with-labels")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(
+        description="Validate h5ad files with HCA schema",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  poetry run python validate_file.py data.h5ad
+  poetry run python validate_file.py data.h5ad --with-labels
+        """
+    )
+    parser.add_argument(
+        "file",
+        help="Path to the h5ad file to validate"
+    )
+    parser.add_argument(
+        "--with-labels",
+        action="store_true",
+        help="Include label validation (gene ID checks, etc.). Default: skip labels"
+    )
     
-    h5ad_file = sys.argv[1]
-    ignore_labels = "--with-labels" not in sys.argv
+    args = parser.parse_args()
+    h5ad_file = args.file
+    ignore_labels = not args.with_labels
     
     print(f"\n{'=' * SEPARATOR_WIDTH}")
     print(f"HCA Schema Validator")

--- a/hca_schema_validator/validate_file.py
+++ b/hca_schema_validator/validate_file.py
@@ -9,6 +9,9 @@ Usage:
 import sys
 from hca_schema_validator import HCAValidator
 
+# Display constants
+SEPARATOR_WIDTH = 70
+
 def main():
     # Parse command-line arguments
     if len(sys.argv) < 2:
@@ -21,33 +24,33 @@ def main():
     h5ad_file = sys.argv[1]
     ignore_labels = "--with-labels" not in sys.argv
     
-    print(f"\n{'='*70}")
+    print(f"\n{'=' * SEPARATOR_WIDTH}")
     print(f"HCA Schema Validator")
-    print(f"{'='*70}")
+    print(f"{'=' * SEPARATOR_WIDTH}")
     print(f"File: {h5ad_file}")
     print(f"Ignore Labels: {ignore_labels}")
-    print(f"{'='*70}\n")
+    print(f"{'=' * SEPARATOR_WIDTH}\n")
     
     validator = HCAValidator(ignore_labels=ignore_labels)
     is_valid = validator.validate_adata(h5ad_file)
     
-    print(f"\n{'='*70}")
+    print(f"\n{'=' * SEPARATOR_WIDTH}")
     if is_valid:
         print("✅ VALID - File passes HCA schema validation")
     else:
         print("❌ INVALID - File has validation errors")
-    print(f"{'='*70}\n")
+    print(f"{'=' * SEPARATOR_WIDTH}\n")
     
     if validator.errors:
         print(f"ERRORS ({len(validator.errors)}):")
-        print("-" * 70)
+        print("-" * SEPARATOR_WIDTH)
         for i, error in enumerate(validator.errors, 1):
             print(f"{i}. {error}")
         print()
     
     if validator.warnings:
         print(f"WARNINGS ({len(validator.warnings)}):")
-        print("-" * 70)
+        print("-" * SEPARATOR_WIDTH)
         for i, warning in enumerate(validator.warnings, 1):
             print(f"{i}. {warning}")
         print()

--- a/hca_schema_validator/validate_file.py
+++ b/hca_schema_validator/validate_file.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Simple script to validate h5ad files with HCA schema.
+
+Usage:
+    poetry run python validate_file.py <path/to/file.h5ad>
+    poetry run python validate_file.py <path/to/file.h5ad> --with-labels
+"""
+import sys
+from hca_schema_validator import HCAValidator
+
+def main():
+    # Parse command-line arguments
+    if len(sys.argv) < 2:
+        print("Error: Please provide a file path")
+        print("\nUsage:")
+        print("  poetry run python validate_file.py <path/to/file.h5ad>")
+        print("  poetry run python validate_file.py <path/to/file.h5ad> --with-labels")
+        sys.exit(1)
+    
+    h5ad_file = sys.argv[1]
+    ignore_labels = "--with-labels" not in sys.argv
+    
+    print(f"\n{'='*70}")
+    print(f"HCA Schema Validator")
+    print(f"{'='*70}")
+    print(f"File: {h5ad_file}")
+    print(f"Ignore Labels: {ignore_labels}")
+    print(f"{'='*70}\n")
+    
+    validator = HCAValidator(ignore_labels=ignore_labels)
+    is_valid = validator.validate_adata(h5ad_file)
+    
+    print(f"\n{'='*70}")
+    if is_valid:
+        print("✅ VALID - File passes HCA schema validation")
+    else:
+        print("❌ INVALID - File has validation errors")
+    print(f"{'='*70}\n")
+    
+    if validator.errors:
+        print(f"ERRORS ({len(validator.errors)}):")
+        print("-" * 70)
+        for i, error in enumerate(validator.errors, 1):
+            print(f"{i}. {error}")
+        print()
+    
+    if validator.warnings:
+        print(f"WARNINGS ({len(validator.warnings)}):")
+        print("-" * 70)
+        for i, warning in enumerate(validator.warnings, 1):
+            print(f"{i}. {warning}")
+        print()
+    
+    if not validator.errors and not validator.warnings:
+        print("No errors or warnings! 🎉\n")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces significant improvements to the HCA schema validator by implementing HCA-specific schema validation logic, updating tests to reflect these changes, and adding a command-line script for validating files. The most important changes are grouped below.

**HCA-Specific Validation Logic:**

* The `HCAValidator` class now loads and uses an HCA-specific schema definition, ensuring that fields like `organism` and `organism_ontology_term_id` are validated in `obs` instead of `uns`, diverging from the default CELLxGENE schema. This is achieved by overriding the schema loading logic and referencing a new schema definition YAML file. [[1]](diffhunk://#diff-e30a95757981fdc5141a97306b0f58eaeb2c466dd3dc118f8d3171072900870aR3-R15) [[2]](diffhunk://#diff-e30a95757981fdc5141a97306b0f58eaeb2c466dd3dc118f8d3171072900870aR26-R48)
* Constants for schema versioning and reference URLs are defined in `__init__.py` before imports to avoid circular dependencies.

**Testing Updates:**

* Tests are updated to expect the new HCA schema behavior, including failing validation for files with `organism` in `uns` and passing when `organism_ontology_term_id` is correctly in `obs`. A new test explicitly checks acceptance of the HCA requirement. [[1]](diffhunk://#diff-6a7a0f76f03d9d31d0e1353c6fce3fb5b1096aff8ac1350fff0786dcc002531bL47-R53) [[2]](diffhunk://#diff-6a7a0f76f03d9d31d0e1353c6fce3fb5b1096aff8ac1350fff0786dcc002531bL56-R68) [[3]](diffhunk://#diff-6a7a0f76f03d9d31d0e1353c6fce3fb5b1096aff8ac1350fff0786dcc002531bR84-R113)

**Developer Experience:**

* A new script, `validate_file.py`, provides a simple command-line tool to validate `.h5ad` files against the HCA schema, displaying clear error and warning messages for users.